### PR TITLE
Add minimal DVC demo

### DIFF
--- a/.dvc/.gitignore
+++ b/.dvc/.gitignore
@@ -1,0 +1,3 @@
+/config.local
+/tmp
+/cache

--- a/.dvc/config
+++ b/.dvc/config
@@ -1,0 +1,4 @@
+[core]
+    remote = localremote
+['remote "localremote"']
+    url = ../dvc_storage

--- a/.dvcignore
+++ b/.dvcignore
@@ -1,0 +1,3 @@
+# Add patterns of files dvc should ignore, which could improve
+# the performance. Learn more at
+# https://dvc.org/doc/user-guide/dvcignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+dvc_storage/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,39 @@
 # DVC-demo
-Test [DVC](https://dvc.org/) capabilites
+
+This repository demonstrates a minimal [DVC](https://dvc.org/) workflow.
+It is inspired by Stian Lagstad's blog post about managing large test data
+with DVC and custom GitHub Action runners.
+
+## Setup
+
+Install the required tools:
+
+```bash
+pip install dvc
+```
+
+Initialise the repository and set up a local remote:
+
+```bash
+dvc init
+dvc remote add -d localremote ./dvc_storage
+```
+
+## Pipeline
+
+The repository contains a small example pipeline which converts the contents
+of `data/raw.txt` to uppercase. The stage is defined in `dvc.yaml` and can be
+reproduced with:
+
+```bash
+dvc repro
+```
+
+Data is tracked with DVC and stored in the `localremote` directory.
+
+## Running the demo
+
+1. Modify `data/raw.txt` and run `dvc repro` to generate a new
+   `data/processed.txt`.
+2. Use `dvc push` to store the data in the configured remote.
+3. Use `dvc pull` to retrieve the data on a fresh clone.

--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,0 +1,2 @@
+/raw.txt
+/processed.txt

--- a/data/raw.txt.dvc
+++ b/data/raw.txt.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 6f5902ac237024bdd0c176cb93063dc4
+  size: 12
+  hash: md5
+  path: raw.txt

--- a/dvc.lock
+++ b/dvc.lock
@@ -1,0 +1,18 @@
+schema: '2.0'
+stages:
+  process:
+    cmd: python src/process.py data/raw.txt data/processed.txt
+    deps:
+    - path: data/raw.txt
+      hash: md5
+      md5: 6f5902ac237024bdd0c176cb93063dc4
+      size: 12
+    - path: src/process.py
+      hash: md5
+      md5: ae196579fde6f89fd3c64164fa7e117b
+      size: 188
+    outs:
+    - path: data/processed.txt
+      hash: md5
+      md5: 2cad20c19a8eb9bb11a9f76527aec9bc
+      size: 12

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -1,0 +1,8 @@
+stages:
+  process:
+    cmd: python src/process.py data/raw.txt data/processed.txt
+    deps:
+    - data/raw.txt
+    - src/process.py
+    outs:
+    - data/processed.txt

--- a/src/process.py
+++ b/src/process.py
@@ -1,0 +1,7 @@
+import sys
+in_path, out_path = sys.argv[1:3]
+with open(in_path) as f:
+    data = f.read()
+# simple transform: convert to uppercase
+with open(out_path, 'w') as f:
+    f.write(data.upper())


### PR DESCRIPTION
## Summary
- init DVC and configure a local remote
- create a simple pipeline that uppercases a text file
- track sample data with DVC
- document setup and usage in README
- ignore the local storage directory

## Testing
- `dvc repro`
- `dvc push`


------
https://chatgpt.com/codex/tasks/task_e_687dd07c88e48326b7dad7aa7db5807c