### PR TITLE
Add FASTQ-to-VCF demo pipeline

### DIFF
--- a/.dvc/.gitignore
+++ b/.dvc/.gitignore
@@ -1,0 +1,3 @@
+/config.local
+/tmp
+/cache

--- a/.dvc/config
+++ b/.dvc/config
@@ -1,0 +1,4 @@
+[core]
+    remote = localremote
+['remote "localremote"']
+    url = ../dvc_storage

--- a/.dvcignore
+++ b/.dvcignore
@@ -1,0 +1,3 @@
+# Add patterns of files dvc should ignore, which could improve
+# the performance. Learn more at
+# https://dvc.org/doc/user-guide/dvcignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+dvc_storage/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,42 @@
 # DVC-demo
-Test [DVC](https://dvc.org/) capabilites
+
+This repository demonstrates a minimal [DVC](https://dvc.org/) workflow on
+Linux and macOS. It provides a tiny bioinformatics-style pipeline that
+converts a FASTQ file to a BAM-like file and then to a VCF-like file.
+
+The example is inspired by [Stian Lagstad's blog post](https://stianlagstad.no/2024/10/efficient-management-of-large-test-data-for-nextflow-pipelines-using-dvc-and-custom-github-actions-runners/).
+
+## Setup
+
+Install DVC (works on Linux and macOS):
+
+```bash
+pip install dvc
+```
+
+Initialise the repository and set up a local remote:
+
+```bash
+dvc init
+dvc remote add -d localremote ./dvc_storage
+```
+
+## Pipeline
+
+The pipeline has two stages defined in `dvc.yaml`:
+
+1. `fastq_to_bam` – converts `data/sample.fastq` to a simple BAM-like
+   representation stored in `data/sample.bam`.
+2. `bam_to_vcf` – converts the BAM file to a tiny VCF-like file
+   `data/sample.vcf`.
+
+Reproduce the pipeline with:
+
+```bash
+dvc repro
+```
+
+## Running the demo
+
+After running `dvc repro`, use `dvc push` to store the data in the
+configured remote and `dvc pull` to retrieve it in a fresh clone.

--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,0 +1,3 @@
+/sample.fastq
+/sample.bam
+/sample.vcf

--- a/data/sample.fastq.dvc
+++ b/data/sample.fastq.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 72247785107368373d4752805711bc17
-  size: 54
+- md5: 3185d14500ed42fd393a7b46ee644b43
+  size: 32
   hash: md5
   path: sample.fastq

--- a/data/sample.fastq.dvc
+++ b/data/sample.fastq.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 72247785107368373d4752805711bc17
+  size: 54
+  hash: md5
+  path: sample.fastq

--- a/dvc.lock
+++ b/dvc.lock
@@ -5,8 +5,8 @@ stages:
     deps:
     - path: data/sample.fastq
       hash: md5
-      md5: 72247785107368373d4752805711bc17
-      size: 54
+      md5: 3185d14500ed42fd393a7b46ee644b43
+      size: 32
     - path: src/fastq_to_bam.py
       hash: md5
       md5: 1177b7df7fdf46aab3c1149b86a90977
@@ -14,15 +14,15 @@ stages:
     outs:
     - path: data/sample.bam
       hash: md5
-      md5: cc0993b508e0961f172d04dbedc87e4b
-      size: 41
+      md5: 97402250a88b1d86f25555ac0096070f
+      size: 27
   bam_to_vcf:
     cmd: python src/bam_to_vcf.py data/sample.bam data/sample.vcf
     deps:
     - path: data/sample.bam
       hash: md5
-      md5: cc0993b508e0961f172d04dbedc87e4b
-      size: 41
+      md5: 97402250a88b1d86f25555ac0096070f
+      size: 27
     - path: src/bam_to_vcf.py
       hash: md5
       md5: 817f4e2b7f028a69b3dd037cc4fbfe59
@@ -30,5 +30,5 @@ stages:
     outs:
     - path: data/sample.vcf
       hash: md5
-      md5: 8294424e7195883b1f1144b3d0d56599
-      size: 112
+      md5: cd14d439b5e0d5cff5abaf48f7c5a458
+      size: 106

--- a/dvc.lock
+++ b/dvc.lock
@@ -1,0 +1,34 @@
+schema: '2.0'
+stages:
+  fastq_to_bam:
+    cmd: python src/fastq_to_bam.py data/sample.fastq data/sample.bam
+    deps:
+    - path: data/sample.fastq
+      hash: md5
+      md5: 72247785107368373d4752805711bc17
+      size: 54
+    - path: src/fastq_to_bam.py
+      hash: md5
+      md5: 1177b7df7fdf46aab3c1149b86a90977
+      size: 315
+    outs:
+    - path: data/sample.bam
+      hash: md5
+      md5: cc0993b508e0961f172d04dbedc87e4b
+      size: 41
+  bam_to_vcf:
+    cmd: python src/bam_to_vcf.py data/sample.bam data/sample.vcf
+    deps:
+    - path: data/sample.bam
+      hash: md5
+      md5: cc0993b508e0961f172d04dbedc87e4b
+      size: 41
+    - path: src/bam_to_vcf.py
+      hash: md5
+      md5: 817f4e2b7f028a69b3dd037cc4fbfe59
+      size: 448
+    outs:
+    - path: data/sample.vcf
+      hash: md5
+      md5: 8294424e7195883b1f1144b3d0d56599
+      size: 112

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -1,0 +1,15 @@
+stages:
+  fastq_to_bam:
+    cmd: python src/fastq_to_bam.py data/sample.fastq data/sample.bam
+    deps:
+      - data/sample.fastq
+      - src/fastq_to_bam.py
+    outs:
+      - data/sample.bam
+  bam_to_vcf:
+    cmd: python src/bam_to_vcf.py data/sample.bam data/sample.vcf
+    deps:
+      - data/sample.bam
+      - src/bam_to_vcf.py
+    outs:
+      - data/sample.vcf

--- a/src/bam_to_vcf.py
+++ b/src/bam_to_vcf.py
@@ -1,0 +1,14 @@
+import sys
+
+in_bam, out_vcf = sys.argv[1:3]
+
+with open(in_bam) as fi, open(out_vcf, 'w') as fo:
+    fo.write('##fileformat=VCFv4.2\n')
+    fo.write('#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n')
+    for idx, line in enumerate(fi):
+        if line.startswith('@'):
+            continue
+        name, seq = line.strip().split('\t')
+        ref = seq[0]
+        alt = seq[-1]
+        fo.write(f'chr1\t{idx+1}\t{name}\t{ref}\t{alt}\t.\tPASS\t.\n')

--- a/src/fastq_to_bam.py
+++ b/src/fastq_to_bam.py
@@ -1,0 +1,11 @@
+import sys
+
+in_fastq, out_bam = sys.argv[1:3]
+
+with open(in_fastq) as fi, open(out_bam, 'w') as fo:
+    fo.write('@HD\tVN:1.0\n')
+    lines = [l.strip() for l in fi if l.strip()]
+    for i in range(0, len(lines), 4):
+        name = lines[i].lstrip('@')
+        seq = lines[i+1]
+        fo.write(f"{name}\t{seq}\n")


### PR DESCRIPTION
## Summary
- replace uppercase example with small bioinformatics-style pipeline
- track a sample FASTQ file with DVC
- convert FASTQ to BAM and then BAM to VCF
- update README with cross-platform instructions

## Testing
- `dvc repro`
- `dvc push`


------
https://chatgpt.com/codex/tasks/task_e_687dd07c88e48326b7dad7aa7db5807c